### PR TITLE
feat: add AI Gateway feedback generation and display

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -4,10 +4,12 @@
     "": {
       "name": "daily-drawing-fundamentals-trainer",
       "dependencies": {
+        "@ai-sdk/react": "^3.0.151",
         "@base-ui/react": "^1.3.0",
         "@clerk/nextjs": "^7.0.7",
         "@tanstack/react-query": "^5.95.2",
         "@vercel/blob": "^2.3.3",
+        "ai": "^6.0.149",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "convex": "^1.34.0",
@@ -21,6 +23,7 @@
         "svix": "^1.89.0",
         "tailwind-merge": "^3.5.0",
         "tw-animate-css": "^1.4.0",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -62,6 +65,14 @@
     "@actions/io": ["@actions/io@3.0.2", "", {}, "sha512-nRBchcMM+QK1pdjO7/idu86rbJI5YHUKCvKs0KxnSYbVe3F51UfGxuZX4Qy/fWlp6l7gWFwIkrOzN+oUK03kfw=="],
 
     "@adobe/css-tools": ["@adobe/css-tools@4.4.4", "", {}, "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg=="],
+
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.91", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@vercel/oidc": "3.1.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-J39Dh6Gyg6HjG3A7OFKnJMp3QyZ3Eex+XDiX8aFBdRwwZm3jGWaMhkCxQPH7yiQ9kRiErZwHXX/Oexx4SyGGGA=="],
+
+    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.8", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-oGMAgGoQdBXbZqNG0Ze56CHjDZ1IDYOwGYxYjO5KLSlz5HiNQ9udIXsPZ61VWaHGZ5XW/jyjmr6t2xz2jGVwbQ=="],
+
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.23", "", { "dependencies": { "@ai-sdk/provider": "3.0.8", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.6" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-z8GlDaCmRSDlqkMF2f4/RFgWxdarvIbyuk+m6WXT1LYgsnGiXRJGTD2Z1+SDl3LqtFuRtGX1aghYvQLoHL/9pg=="],
+
+    "@ai-sdk/react": ["@ai-sdk/react@3.0.151", "", { "dependencies": { "@ai-sdk/provider-utils": "4.0.23", "ai": "6.0.149", "swr": "^2.2.5", "throttleit": "2.1.0" }, "peerDependencies": { "react": "^18 || ~19.0.1 || ~19.1.2 || ^19.2.1" } }, "sha512-Y6jGr3amKVG4tisMaIymbsbI/uNrbSO1OH9M7WBHeuTLbig7Ejn/DoVW/agOC20294nFdOTu73Z2XU14XLPwxg=="],
 
     "@alloc/quick-lru": ["@alloc/quick-lru@5.2.0", "", {}, "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw=="],
 
@@ -463,6 +474,8 @@
 
     "@open-draft/until": ["@open-draft/until@2.1.0", "", {}, "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg=="],
 
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.0", "", {}, "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg=="],
+
     "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
 
     "@pkgr/core": ["@pkgr/core@0.2.9", "", {}, "sha512-QNqXyfVS2wm9hweSYD2O7F0G06uurj9kZ96TRQE5Y9hU7+tgdZwIkbAKc5Ocy1HxEY2kuDQa6cQ1WRs/O5LFKA=="],
@@ -506,6 +519,8 @@
     "@sinonjs/fake-timers": ["@sinonjs/fake-timers@15.1.1", "", { "dependencies": { "@sinonjs/commons": "^3.0.1" } }, "sha512-cO5W33JgAPbOh07tvZjUOJ7oWhtaqGHiZw+11DPbyqh2kHTBc3eF/CjJDeQ4205RLQsX6rxCuYOroFQwl7JDRw=="],
 
     "@stablelib/base64": ["@stablelib/base64@1.0.1", "", {}, "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ=="],
+
+    "@standard-schema/spec": ["@standard-schema/spec@1.1.0", "", {}, "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w=="],
 
     "@swc/helpers": ["@swc/helpers@0.5.15", "", { "dependencies": { "tslib": "^2.8.0" } }, "sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g=="],
 
@@ -671,6 +686,8 @@
 
     "@vercel/blob": ["@vercel/blob@2.3.3", "", { "dependencies": { "async-retry": "^1.3.3", "is-buffer": "^2.0.5", "is-node-process": "^1.2.0", "throttleit": "^2.1.0", "undici": "^6.23.0" } }, "sha512-MtD7VLo6hU07eHR7bmk5SIMD290q574UaNYTe46qeyRT+hWrCy26CoAqfd7PnIefVXvRehRZBzukxuTO9iGTVg=="],
 
+    "@vercel/oidc": ["@vercel/oidc@3.1.0", "", {}, "sha512-Fw28YZpRnA3cAHHDlkt7xQHiJ0fcL+NRcIqsocZQUSmbzeIKRpwttJjik5ZGanXP+vlA4SbTg+AbA3bP363l+w=="],
+
     "accepts": ["accepts@2.0.0", "", { "dependencies": { "mime-types": "^3.0.0", "negotiator": "^1.0.0" } }, "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
@@ -682,6 +699,8 @@
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
     "aggregate-error": ["aggregate-error@3.1.0", "", { "dependencies": { "clean-stack": "^2.0.0", "indent-string": "^4.0.0" } }, "sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA=="],
+
+    "ai": ["ai@6.0.149", "", { "dependencies": { "@ai-sdk/gateway": "3.0.91", "@ai-sdk/provider": "3.0.8", "@ai-sdk/provider-utils": "4.0.23", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-3asRb/m3ZGH7H4+VTuTgj8eQYJZ9IJUmV0ljLslY92mQp6Zj+NVn4SmFj0TBr2Y/wFBWC3xgn++47tSGOXxdbw=="],
 
     "ajv": ["ajv@6.14.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw=="],
 
@@ -1397,6 +1416,8 @@
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
+    "json-schema": ["json-schema@0.4.0", "", {}, "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="],
+
     "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
 
     "json-schema-typed": ["json-schema-typed@8.0.2", "", {}, "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA=="],
@@ -1915,6 +1936,8 @@
 
     "svix": ["svix@1.89.0", "", { "dependencies": { "standardwebhooks": "1.0.0", "uuid": "^10.0.0" } }, "sha512-Yg/5OtdjN3zjWoQSoX+mkauUtLKiW/+DQWKcG2VaEfWoBBB9NmZoKMw7rQQVU5Nn/Wko3kNbo4cvo/ms48d2KQ=="],
 
+    "swr": ["swr@2.4.1", "", { "dependencies": { "dequal": "^2.0.3", "use-sync-external-store": "^1.6.0" }, "peerDependencies": { "react": "^16.11.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-2CC6CiKQtEwaEeNiqWTAw9PGykW8SR5zZX8MZk6TeAvEAnVS7Visz8WzphqgtQ8v2xz/4Q5K+j+SeMaKXeeQIA=="],
+
     "symbol-tree": ["symbol-tree@3.2.4", "", {}, "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw=="],
 
     "synckit": ["synckit@0.11.12", "", { "dependencies": { "@pkgr/core": "^0.2.9" } }, "sha512-Bh7QjT8/SuKUIfObSXNHNSK6WHo6J1tHCqJsuaFDP7gP0fkzSfTxI8y85JrppZ0h8l0maIgc2tfuZQ6/t3GtnQ=="],
@@ -2111,7 +2134,7 @@
 
     "yoctocolors-cjs": ["yoctocolors-cjs@2.1.3", "", {}, "sha512-U/PBtDf35ff0D8X8D0jfdzHYEPFxAI7jJlxZXwCSez5M3190m+QobIfh+sWDWSHMCWWJN2AWamkegn6vr6YBTw=="],
 
-    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+    "zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "zod-to-json-schema": ["zod-to-json-schema@3.25.1", "", { "peerDependencies": { "zod": "^3.25 || ^4" } }, "sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA=="],
 
@@ -2156,8 +2179,6 @@
     "@istanbuljs/load-nyc-config/js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "@modelcontextprotocol/sdk/ajv": ["ajv@8.18.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A=="],
-
-    "@modelcontextprotocol/sdk/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "@next/eslint-plugin-next/fast-glob": ["fast-glob@3.3.1", "", { "dependencies": { "@nodelib/fs.stat": "^2.0.2", "@nodelib/fs.walk": "^1.2.3", "glob-parent": "^5.1.2", "merge2": "^1.3.0", "micromatch": "^4.0.4" } }, "sha512-kNFPyjhh5cKjrUltxs+wFx+ZkbRaxxmZ+X0ZU31SOsxCEtP9VPgtq2teZw1DebupL5GmDaNQ6yKMMVcM41iqDg=="],
 
@@ -2238,8 +2259,6 @@
     "eslint-plugin-react/resolve": ["resolve@2.0.0-next.6", "", { "dependencies": { "es-errors": "^1.3.0", "is-core-module": "^2.16.1", "node-exports-info": "^1.6.0", "object-keys": "^1.1.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-3JmVl5hMGtJ3kMmB3zi3DL25KfkCEyy3Tw7Gmw7z5w8M9WlwoPFnIvwChzu1+cF3iaK3sp18hhPz8ANeimdJfA=="],
 
     "eslint-plugin-react/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
-
-    "eslint-plugin-react-hooks/zod": ["zod@4.3.6", "", {}, "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg=="],
 
     "express/cookie": ["cookie@0.7.2", "", {}, "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w=="],
 
@@ -2610,6 +2629,8 @@
     "shadcn/diff": ["diff@8.0.4", "", {}, "sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw=="],
 
     "shadcn/execa": ["execa@9.6.1", "", { "dependencies": { "@sindresorhus/merge-streams": "^4.0.0", "cross-spawn": "^7.0.6", "figures": "^6.1.0", "get-stream": "^9.0.0", "human-signals": "^8.0.1", "is-plain-obj": "^4.1.0", "is-stream": "^4.0.1", "npm-run-path": "^6.0.0", "pretty-ms": "^9.2.0", "signal-exit": "^4.1.0", "strip-final-newline": "^4.0.0", "yoctocolors": "^2.1.1" } }, "sha512-9Be3ZoN4LmYR90tUoVu2te2BsbzHfhJyfEiAVfz7N5/zv+jduIfLrV2xdQXOHbaD6KgpGdO9PRPM1Y4Q9QkPkA=="],
+
+    "shadcn/zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
 
     "signale/chalk": ["chalk@2.4.2", "", { "dependencies": { "ansi-styles": "^3.2.1", "escape-string-regexp": "^1.0.5", "supports-color": "^5.3.0" } }, "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ=="],
 

--- a/convex/feedback.ts
+++ b/convex/feedback.ts
@@ -1,0 +1,60 @@
+import { mutation, query } from "./_generated/server";
+import { v } from "convex/values";
+
+export const upsert = mutation({
+  args: {
+    submissionId: v.id("submissions"),
+    scores: v.object({
+      proportion: v.number(),
+      lineQuality: v.number(),
+      composition: v.number(),
+    }),
+    hints: v.array(v.string()),
+    strengths: v.array(v.string()),
+    summary: v.string(),
+  },
+  handler: async (ctx, args) => {
+    // Update submission status
+    await ctx.db.patch(args.submissionId, { feedbackStatus: "completed" });
+
+    // Upsert feedback
+    const existing = await ctx.db
+      .query("feedback")
+      .withIndex("by_submission", (q) =>
+        q.eq("submissionId", args.submissionId)
+      )
+      .first();
+
+    if (existing) {
+      await ctx.db.patch(existing._id, {
+        scores: args.scores,
+        hints: args.hints,
+        strengths: args.strengths,
+        summary: args.summary,
+        createdAt: Date.now(),
+      });
+      return existing._id;
+    }
+
+    return await ctx.db.insert("feedback", {
+      submissionId: args.submissionId,
+      scores: args.scores,
+      hints: args.hints,
+      strengths: args.strengths,
+      summary: args.summary,
+      createdAt: Date.now(),
+    });
+  },
+});
+
+export const getBySubmission = query({
+  args: { submissionId: v.id("submissions") },
+  handler: async (ctx, args) => {
+    return await ctx.db
+      .query("feedback")
+      .withIndex("by_submission", (q) =>
+        q.eq("submissionId", args.submissionId)
+      )
+      .first();
+  },
+});

--- a/convex/submissions.ts
+++ b/convex/submissions.ts
@@ -56,6 +56,20 @@ export const getLatestForLesson = query({
   },
 });
 
+export const markFailed = mutation({
+  args: { submissionId: v.id("submissions") },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.submissionId, { feedbackStatus: "failed" });
+  },
+});
+
+export const markPending = mutation({
+  args: { submissionId: v.id("submissions") },
+  handler: async (ctx, args) => {
+    await ctx.db.patch(args.submissionId, { feedbackStatus: "pending" });
+  },
+});
+
 export const getById = query({
   args: { id: v.id("submissions") },
   handler: async (ctx, args) => {

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {
+    "@ai-sdk/react": "^3.0.151",
     "@base-ui/react": "^1.3.0",
     "@clerk/nextjs": "^7.0.7",
     "@tanstack/react-query": "^5.95.2",
     "@vercel/blob": "^2.3.3",
+    "ai": "^6.0.149",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "convex": "^1.34.0",
@@ -29,7 +31,8 @@
     "sonner": "^2.0.7",
     "svix": "^1.89.0",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0"
+    "tw-animate-css": "^1.4.0",
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/src/app/(app)/lessons/[slug]/feedback/[submissionId]/page.tsx
+++ b/src/app/(app)/lessons/[slug]/feedback/[submissionId]/page.tsx
@@ -1,0 +1,12 @@
+import { FeedbackDisplay } from "@/components/feedback-display";
+
+export const dynamic = "force-dynamic";
+
+export default async function FeedbackPage({
+  params,
+}: {
+  params: Promise<{ slug: string; submissionId: string }>;
+}) {
+  const { slug, submissionId } = await params;
+  return <FeedbackDisplay slug={slug} submissionId={submissionId} />;
+}

--- a/src/app/api/generate-feedback/route.ts
+++ b/src/app/api/generate-feedback/route.ts
@@ -1,0 +1,127 @@
+import { NextResponse } from "next/server";
+import { auth } from "@clerk/nextjs/server";
+import { generateText, Output } from "ai";
+import { ConvexHttpClient } from "convex/browser";
+import { feedbackSchema } from "@/lib/feedback-schema";
+
+const MODEL = "openai/gpt-5.4";
+const MAX_RETRIES = 2;
+
+export async function POST(request: Request) {
+  const { userId } = await auth();
+  if (!userId) {
+    return NextResponse.json({ error: "Unauthenticated" }, { status: 401 });
+  }
+
+  const body = (await request.json()) as {
+    submissionId: string;
+    lessonSlug: string;
+    imageUrl: string;
+  };
+
+  const { submissionId, lessonSlug, imageUrl } = body;
+
+  if (!submissionId || !lessonSlug || !imageUrl) {
+    return NextResponse.json({ error: "Missing fields" }, { status: 400 });
+  }
+
+  const CONVEX_URL = process.env.NEXT_PUBLIC_CONVEX_URL;
+  if (!CONVEX_URL) {
+    return NextResponse.json(
+      { error: "Convex not configured" },
+      { status: 500 }
+    );
+  }
+
+  const convex = new ConvexHttpClient(CONVEX_URL);
+
+  // Fetch lesson context for the AI prompt
+  let lesson: { title: string; instructions: string; description: string } | null = null;
+  try {
+    lesson = await convex.query(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      "lessons:getBySlug" as any,
+      { slug: lessonSlug }
+    );
+  } catch {
+    return NextResponse.json({ error: "Lesson lookup failed" }, { status: 500 });
+  }
+
+  if (!lesson) {
+    return NextResponse.json({ error: "Lesson not found" }, { status: 404 });
+  }
+
+  const prompt = `You are an experienced drawing instructor evaluating a beginner art student's sketch.
+
+LESSON: ${lesson.title}
+DESCRIPTION: ${lesson.description}
+INSTRUCTIONS GIVEN: ${lesson.instructions}
+
+The student submitted an image at this URL. Look at the image and provide structured feedback.
+
+Score from 1 (poor) to 10 (excellent):
+- proportion: how well-proportioned shapes and forms are
+- lineQuality: confidence and consistency of line work
+- composition: overall arrangement and use of space
+
+Provide:
+- 1-2 specific strengths (what they did well)
+- 2-4 specific, actionable hints to improve
+- A 1-2 sentence overall summary
+
+Be encouraging but honest. Focus on the lesson objectives.`;
+
+  // Retry loop
+  let lastError: unknown = null;
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const { output } = await generateText({
+        model: MODEL,
+        output: Output.object({ schema: feedbackSchema }),
+        messages: [
+          {
+            role: "user",
+            content: [
+              { type: "text", text: prompt },
+              { type: "image", image: new URL(imageUrl) },
+            ],
+          },
+        ],
+      });
+
+      // Save feedback to Convex
+      await convex.mutation(
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        "feedback:upsert" as any,
+        { submissionId, ...output }
+      );
+
+      return NextResponse.json({ success: true, feedback: output });
+    } catch (error) {
+      lastError = error;
+      console.error(`AI feedback attempt ${attempt + 1} failed:`, error);
+      if (attempt < MAX_RETRIES) {
+        await new Promise((r) => setTimeout(r, 1000 * Math.pow(2, attempt)));
+      }
+    }
+  }
+
+  // All retries failed — mark submission as failed
+  try {
+    await convex.mutation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      "submissions:markFailed" as any,
+      { submissionId }
+    );
+  } catch (e) {
+    console.error("Failed to mark submission as failed:", e);
+  }
+
+  return NextResponse.json(
+    {
+      error: "Feedback generation failed after retries",
+      details: lastError instanceof Error ? lastError.message : String(lastError),
+    },
+    { status: 500 }
+  );
+}

--- a/src/components/feedback-display.tsx
+++ b/src/components/feedback-display.tsx
@@ -1,0 +1,196 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { useQuery } from "convex/react";
+import { ArrowLeft, Loader2, RefreshCw, Sparkles, Lightbulb, AlertCircle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { ScoreBar } from "@/components/score-bar";
+import { api } from "@/lib/convex";
+
+interface FeedbackDisplayProps {
+  slug: string;
+  submissionId: string;
+}
+
+export function FeedbackDisplay({ slug, submissionId }: FeedbackDisplayProps) {
+  const submission = useQuery(api.submissions.getById, {
+    id: submissionId,
+  });
+  const feedback = useQuery(api.feedback.getBySubmission, {
+    submissionId: submissionId,
+  });
+  const [isRetrying, setIsRetrying] = useState(false);
+
+  const handleRetry = async () => {
+    if (!submission) return;
+    setIsRetrying(true);
+    try {
+      const res = await fetch("/api/generate-feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          submissionId,
+          lessonSlug: slug,
+          imageUrl: submission.imageUrl,
+        }),
+      });
+      if (!res.ok) throw new Error("Retry failed");
+    } catch (err) {
+      console.error(err);
+    } finally {
+      setIsRetrying(false);
+    }
+  };
+
+  if (submission === undefined) {
+    return (
+      <div className="space-y-4 max-w-3xl">
+        <div className="h-8 w-48 animate-pulse rounded bg-muted" />
+        <div className="h-96 animate-pulse rounded-lg bg-muted" />
+      </div>
+    );
+  }
+
+  if (!submission) {
+    return (
+      <div className="space-y-4 max-w-3xl">
+        <p className="text-muted-foreground">Submission not found.</p>
+        <Link href={`/lessons/${slug}`}>
+          <Button variant="outline">Back to lesson</Button>
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6 max-w-3xl">
+      <Link
+        href={`/lessons/${slug}`}
+        className="inline-flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ArrowLeft className="h-4 w-4" />
+        Back to lesson
+      </Link>
+
+      <div>
+        <h1 className="text-2xl font-semibold">Your feedback</h1>
+        <p className="text-sm text-muted-foreground mt-1">
+          {new Date(submission.submittedAt).toLocaleDateString(undefined, {
+            year: "numeric",
+            month: "long",
+            day: "numeric",
+            hour: "2-digit",
+            minute: "2-digit",
+          })}
+        </p>
+      </div>
+
+      <Card className="overflow-hidden">
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          src={submission.imageUrl}
+          alt="Your submitted sketch"
+          className="w-full max-h-[60vh] object-contain bg-muted"
+        />
+      </Card>
+
+      {submission.feedbackStatus === "pending" && (
+        <Card className="p-8">
+          <div className="flex flex-col items-center text-center gap-3">
+            <Loader2 className="h-8 w-8 animate-spin text-primary" />
+            <p className="font-medium">Generating feedback...</p>
+            <p className="text-sm text-muted-foreground">
+              Our AI is analyzing your sketch. This usually takes 10–30 seconds.
+            </p>
+          </div>
+        </Card>
+      )}
+
+      {submission.feedbackStatus === "failed" && (
+        <Card className="p-6 border-destructive/50">
+          <div className="flex items-start gap-3">
+            <AlertCircle className="h-5 w-5 text-destructive mt-0.5" />
+            <div className="flex-1 space-y-3">
+              <div>
+                <p className="font-medium">Feedback could not be generated</p>
+                <p className="text-sm text-muted-foreground mt-1">
+                  Something went wrong while analyzing your sketch. Try again
+                  in a moment.
+                </p>
+              </div>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={handleRetry}
+                disabled={isRetrying}
+              >
+                {isRetrying ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <RefreshCw className="h-4 w-4" />
+                )}
+                {isRetrying ? "Retrying..." : "Retry"}
+              </Button>
+            </div>
+          </div>
+        </Card>
+      )}
+
+      {submission.feedbackStatus === "completed" && feedback && (
+        <>
+          <Card className="p-6 space-y-4">
+            <h2 className="font-medium">Scores</h2>
+            <ScoreBar label="proportion" score={feedback.scores.proportion} />
+            <ScoreBar label="line quality" score={feedback.scores.lineQuality} />
+            <ScoreBar label="composition" score={feedback.scores.composition} />
+          </Card>
+
+          <Card className="p-6">
+            <h2 className="font-medium mb-2">Summary</h2>
+            <p className="text-sm text-muted-foreground leading-relaxed">
+              {feedback.summary}
+            </p>
+          </Card>
+
+          <Card className="p-6">
+            <div className="flex items-center gap-2 mb-3">
+              <Sparkles className="h-4 w-4 text-green-500" />
+              <h2 className="font-medium">Strengths</h2>
+            </div>
+            <ul className="space-y-2">
+              {feedback.strengths.map((s: string, i: number) => (
+                <li
+                  key={i}
+                  className="text-sm text-muted-foreground flex items-start gap-2"
+                >
+                  <span className="text-green-500 mt-0.5">•</span>
+                  {s}
+                </li>
+              ))}
+            </ul>
+          </Card>
+
+          <Card className="p-6">
+            <div className="flex items-center gap-2 mb-3">
+              <Lightbulb className="h-4 w-4 text-amber-500" />
+              <h2 className="font-medium">To improve</h2>
+            </div>
+            <ul className="space-y-2">
+              {feedback.hints.map((h: string, i: number) => (
+                <li
+                  key={i}
+                  className="text-sm text-muted-foreground flex items-start gap-2"
+                >
+                  <span className="text-amber-500 mt-0.5">•</span>
+                  {h}
+                </li>
+              ))}
+            </ul>
+          </Card>
+        </>
+      )}
+    </div>
+  );
+}

--- a/src/components/score-bar.tsx
+++ b/src/components/score-bar.tsx
@@ -1,0 +1,42 @@
+import { cn } from "@/lib/utils";
+
+interface ScoreBarProps {
+  label: string;
+  score: number; // 1-10
+}
+
+export function ScoreBar({ label, score }: ScoreBarProps) {
+  const clamped = Math.max(1, Math.min(10, score));
+  const pct = (clamped / 10) * 100;
+
+  const colorClass =
+    clamped >= 7
+      ? "bg-green-500"
+      : clamped >= 4
+        ? "bg-amber-500"
+        : "bg-red-500";
+
+  const labelColor =
+    clamped >= 7
+      ? "text-green-600"
+      : clamped >= 4
+        ? "text-amber-600"
+        : "text-red-600";
+
+  return (
+    <div className="space-y-1.5">
+      <div className="flex items-baseline justify-between">
+        <span className="text-sm font-medium capitalize">{label}</span>
+        <span className={cn("text-sm font-semibold tabular-nums", labelColor)}>
+          {clamped.toFixed(1)} / 10
+        </span>
+      </div>
+      <div className="h-2 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className={cn("h-full transition-all duration-500", colorClass)}
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/submit-form.tsx
+++ b/src/components/submit-form.tsx
@@ -64,6 +64,17 @@ export function SubmitForm({ slug }: { slug: string }) {
         imageUrl: result.url,
       });
 
+      // Fire AI feedback request (don't await — Convex subscription will surface results)
+      fetch("/api/generate-feedback", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          submissionId,
+          lessonSlug: slug,
+          imageUrl: result.url,
+        }),
+      }).catch((err) => console.error("Failed to trigger AI feedback:", err));
+
       toast.success("Sketch submitted!");
       router.push(`/lessons/${slug}/feedback/${submissionId}`);
     } catch (error) {

--- a/src/lib/feedback-schema.ts
+++ b/src/lib/feedback-schema.ts
@@ -1,0 +1,36 @@
+import { z } from "zod";
+
+export const feedbackSchema = z.object({
+  scores: z.object({
+    proportion: z
+      .number()
+      .min(1)
+      .max(10)
+      .describe("How well-proportioned the drawing is, 1-10"),
+    lineQuality: z
+      .number()
+      .min(1)
+      .max(10)
+      .describe("Confidence and consistency of line work, 1-10"),
+    composition: z
+      .number()
+      .min(1)
+      .max(10)
+      .describe("Overall composition and use of space, 1-10"),
+  }),
+  hints: z
+    .array(z.string())
+    .min(2)
+    .max(4)
+    .describe("2-4 specific, actionable improvement suggestions"),
+  strengths: z
+    .array(z.string())
+    .min(1)
+    .max(2)
+    .describe("1-2 things the artist did well"),
+  summary: z
+    .string()
+    .describe("1-2 sentence overall assessment"),
+});
+
+export type Feedback = z.infer<typeof feedbackSchema>;


### PR DESCRIPTION
## Summary
- Install `ai`, `@ai-sdk/react`, `zod`
- Define feedback Zod schema (scores, hints, strengths, summary)
- Create `/api/generate-feedback` Next.js API route with retry logic + structured output
- Add `convex/feedback.ts` with `upsert` mutation and `getBySubmission` query
- Add `submissions.markFailed` and `markPending` mutations
- Wire submit form to fire AI feedback after upload (fire-and-forget)
- Build feedback display page at `/lessons/[slug]/feedback/[submissionId]`
- Create `ScoreBar` component with color-coded ranges (green/amber/red)
- Three states: pending, completed, failed (with retry button)

## Related Issues
Closes #19, Closes #20

## Environment Variables
- AI Gateway must be enabled in Vercel dashboard
- Run `vercel env pull` to provision `VERCEL_OIDC_TOKEN` for local dev

## Test plan
- [ ] CI passes
- [ ] Submit a sketch → redirect to feedback page
- [ ] Pending state shows spinner with "Generating feedback..."
- [ ] After ~10-30s, feedback appears with 3 score bars
- [ ] If AI fails, retry button works

🤖 Generated with [Claude Code](https://claude.com/claude-code)